### PR TITLE
增加射手多发、投手多投

### DIFF
--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -292,6 +292,30 @@ namespace PVZEvent
 		PlantShootMultipleEvent(int address) : DLLEventTemplate() { Init(address); };
 		PlantShootMultipleEvent() : PlantShootMultipleEvent("onPlantShootMultiple") {};
 	};
+	/// @brief 投手类植物跳过被多投标记的僵尸事件
+	/// @param 植物ID(ECX)，僵尸ID(ESI)
+	/// @return False则跳过该僵尸
+	class PlantPultSkipEvent : public BoolDLLEventTemplate<0x4677E9, 6, 0x467881, REG_ESI, REG_ECX>
+	{
+	public:
+		PlantPultSkipEvent(const char* str) : BoolDLLEventTemplate() { Init(str); };
+		PlantPultSkipEvent(int address) : BoolDLLEventTemplate() { Init(address); };
+		PlantPultSkipEvent() : PlantPultSkipEvent("onPlantPultSkip") {};
+	};
+	/// @brief 四个投手的多投事件
+	/// @param 植物ID（EDI） 植物副武器（ESI）
+	class PlantPultMultipleEvent : public DLLEventTemplate<0x464C1C, 5, REG_ESI, REG_EDI>
+	{
+	public:
+		PlantPultMultipleEvent(const char* str) : DLLEventTemplate() { Init(str); };
+		PlantPultMultipleEvent(int address) : DLLEventTemplate() { Init(address); };
+		PlantPultMultipleEvent() : PlantPultMultipleEvent("onPlantPultMultiple") {};
+	protected:
+		virtual void InitExtra(AsmBuilder& builder)
+		{
+			builder.popad().push_imm32(0x464C34).ret();
+		}
+	};
 
 	/// @brief 创建动画图集事件
 	/// @param 触发事件的动画类型，触发事件的动画定义

--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -283,6 +283,16 @@ namespace PVZEvent
 		PlantUpdateColorEvent() : PlantUpdateColorEvent("onPlantUpdateColor") {};
 	};
 
+	/// @brief 攻击型植物多连发事件，机枪的多发不在这里
+	/// @param 植物ID
+	class PlantShootMultipleEvent : public DLLEventTemplate<0x45F8AD, 5, REG_ESI>
+	{
+	public:
+		PlantShootMultipleEvent(const char* str) : DLLEventTemplate() { Init(str); };
+		PlantShootMultipleEvent(int address) : DLLEventTemplate() { Init(address); };
+		PlantShootMultipleEvent() : PlantShootMultipleEvent("onPlantShootMultiple") {};
+	};
+
 	/// @brief 创建动画图集事件
 	/// @param 触发事件的动画类型，触发事件的动画定义
 	/// @return 是否生成动画图集

--- a/pvzdll/MyPlant/MyPlant.cpp
+++ b/pvzdll/MyPlant/MyPlant.cpp
@@ -210,6 +210,25 @@ void MyPlant::EnableEasterSkin()
 		model.AssignRenderGroupToPrefix(-1, "\0");
 }
 
+byte __asm__FindTargetAndFire[34]
+{
+	MOV_EAX(0),
+	PUSHDWORD(0),
+	PUSHDWORD(0),
+	INVOKE(0x45EF10),
+	MOV_PTR_ADDR_EAX(0),
+	RET
+};
+
+bool MyPlant::FindTargetAndFire(int PlantWeapon)
+{
+	SETARG(__asm__FindTargetAndFire, 1) = this->GetBaseAddress();
+	SETARG(__asm__FindTargetAndFire, 6) = PlantWeapon;
+	SETARG(__asm__FindTargetAndFire, 11) = this->Row;
+	SETARG(__asm__FindTargetAndFire, 29) = Memory::Variable;
+	return (bool)(byte)Memory::Execute(STRING(__asm__FindTargetAndFire));
+}
+
 MyPlant MyPlant::GetByID(int id)
 {
 	if (id)

--- a/pvzdll/MyPlant/MyPlant.cpp
+++ b/pvzdll/MyPlant/MyPlant.cpp
@@ -229,6 +229,44 @@ bool MyPlant::FindTargetAndFire(int PlantWeapon)
 	return (bool)(byte)Memory::Execute(STRING(__asm__FindTargetAndFire));
 }
 
+byte __asm__FindTargetZombie[34]
+{
+	MOV_ECX(0),
+	PUSHDWORD(0),
+	PUSHDWORD(0),
+	INVOKE(0x4675C0),
+	MOV_PTR_ADDR_EAX(0),
+	RET
+};
+
+int MyPlant::FindTargetZombie(int PlantWeapon)
+{
+	SETARG(__asm__FindTargetZombie, 1) = PlantWeapon;
+	SETARG(__asm__FindTargetZombie, 6) = this->Row;
+	SETARG(__asm__FindTargetZombie, 11) = this->GetBaseAddress();
+	SETARG(__asm__FindTargetZombie, 29) = Memory::Variable;
+	return Memory::Execute(STRING(__asm__FindTargetZombie));
+}
+
+byte __asm__Fire[34]
+{
+	PUSHDWORD(0),
+	PUSHDWORD(0),
+	PUSHDWORD(0),
+	PUSHDWORD(0),
+	INVOKE(0x466E00),
+	RET
+};
+
+void MyPlant::Fire(int PlantWeapon, int targetid)
+{
+	SETARG(__asm__Fire, 1) = PlantWeapon;
+	SETARG(__asm__Fire, 6) = this->Row;
+	SETARG(__asm__Fire, 11) = targetid;
+	SETARG(__asm__Fire, 16) = this->GetBaseAddress();
+	Memory::Execute(STRING(__asm__Fire));
+}
+
 MyPlant MyPlant::GetByID(int id)
 {
 	if (id)

--- a/pvzdll/MyPlant/MyPlant.hpp
+++ b/pvzdll/MyPlant/MyPlant.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../framework.h"
 #include "../Const.hpp"
+#include "../MyZombie/MyZombie.hpp"
 
 class MyPlant : public PVZ::Plant
 {
@@ -88,6 +89,14 @@ public:
 	/// @param PlantWeapon 大多数植物=0，裂荚后射、仙人掌在地面射、玉米黄油等，则=1
 	/// @return 返回一个bool，表示植物是否成功索敌
 	bool FindTargetAndFire(int PlantWeapon);
+	/// @brief 植物寻找敌人。
+	/// @param PlantWeapon 大多数植物=0，裂荚后射、仙人掌在地面射、玉米黄油等，则=1
+	/// @return 僵尸ID，仅仅用于开火的参数
+	int FindTargetZombie(int PlantWeapon);
+	/// @brief 植物开火。PVZClass的Shoot()不知道为什么用了会崩溃，这个函数直接调用原版函数466e00
+	/// @param PlantWeapon 大多数植物=0，裂荚后射、仙人掌在地面射、玉米黄油等，则=1
+	/// @param targetid 目标僵尸
+	void Fire(int PlantWeapon,int targetid);
 
 	/// @brief 最大等级
 	static const int MAX_LEVEL = 5;

--- a/pvzdll/MyPlant/MyPlant.hpp
+++ b/pvzdll/MyPlant/MyPlant.hpp
@@ -84,6 +84,10 @@ public:
 	void AddExperience(int val, bool kill_credit = false);
 	/// @brief 启用彩蛋皮
 	void EnableEasterSkin();
+	/// @brief 植物索敌并准备开火。只有除了三线和杨桃的攻击型植物才应当使用这个函数
+	/// @param PlantWeapon 大多数植物=0，裂荚后射、仙人掌在地面射、玉米黄油等，则=1
+	/// @return 返回一个bool，表示植物是否成功索敌
+	bool FindTargetAndFire(int PlantWeapon);
 
 	/// @brief 最大等级
 	static const int MAX_LEVEL = 5;

--- a/pvzdll/MyZombie/MyZombie.hpp
+++ b/pvzdll/MyZombie/MyZombie.hpp
@@ -12,6 +12,8 @@ public:
 	T_PROPERTY(byte, Unknown, __get_Un, __set_Un, 0x71);
 	/// @brief 精英类别
 	T_PROPERTY(byte, EliteType, __get_ElT, __set_ElT, 0x72);
+	/// @brief 僵尸被多投索敌过的标记
+	T_PROPERTY(byte, PultSkip, __get_PultSkip, __set_PultSkip, 0x106);
 	/// @brief 毒的层数
 	INT_PROPERTY(PoisonStack, __get_PoS, __set_PoS, 0x140);
 	/// @brief 最近受到伤害的来源植物 ID

--- a/pvzdll/PlantEvents.cpp
+++ b/pvzdll/PlantEvents.cpp
@@ -110,6 +110,47 @@ void onPlantShootMultiple(MyPlant plant)
 		plant.FindTargetAndFire(0);
 }
 
+bool onPlantPultSkip(MyPlant plant,MyZombie zombie)
+{
+	if (zombie.PultSkip)
+	{
+		if (plant.Type == SeedType::Cabbagepult || plant.Type == SeedType::Kernelpult || plant.Type == SeedType::Melonpult || plant.Type == SeedType::WinterMelon)
+			return false;
+	}
+	return true;
+}
+
+/// @brief 投手同时投出多发子弹
+/// @param plant 植物
+/// @param num 多发数量
+/// @param PlantWeapon 植物副武器
+void PultMultiple(MyPlant plant, int num, int PlantWeapon)
+{
+	for (int i = 0; i < num; i++)
+	{
+		int targetid = plant.FindTargetZombie(PlantWeapon);
+		if (targetid)
+		{
+			MyZombie target{ targetid };
+			plant.Fire(PlantWeapon, targetid);
+			target.PultSkip = 1;
+		}
+	}
+	//清空所有僵尸的PultSkip标记
+	auto zombies = plant.GetBoard().GetAllZombies<MyZombie>();
+	for (auto& zombie : zombies)
+	{
+		zombie.PultSkip = 0;
+	}
+}
+
+void onPlantPultMultiple(MyPlant plant,int PlantWeapon)
+{
+	if (plant.Type == SeedType::Cabbagepult)
+		PultMultiple(plant, 3, PlantWeapon);
+	plant.Fire(PlantWeapon,plant.FindTargetZombie(PlantWeapon));
+}
+
 void InitPlantEvents()
 {
 	PlantInitAfterEvent((int)onPlantInitAfter);
@@ -121,4 +162,6 @@ void InitPlantEvents()
 	PVZEvent::PlantUpdateColorEvent((int)onPlantUpdateColor);
 	PVZEvent::StarfruitFindTargetEvent((int)onStarFruitFindTarget);
 	PVZEvent::PlantShootMultipleEvent((int)onPlantShootMultiple);
+	PVZEvent::PlantPultSkipEvent((int)onPlantPultSkip);
+	PVZEvent::PlantPultMultipleEvent((int)onPlantPultMultiple);
 }

--- a/pvzdll/PlantEvents.cpp
+++ b/pvzdll/PlantEvents.cpp
@@ -102,6 +102,14 @@ int onStarFruitFindTarget(MyPlant plant, MyZombie zombie)
 	return plant.Row == zombie.Row ? 1 : 0;
 }
 
+void onPlantShootMultiple(MyPlant plant)
+{
+	if (plant.Type == SeedType::Cactus && plant.ShootOrProductCountdown == 50)
+		plant.FindTargetAndFire(1);
+	if (plant.Type == SeedType::Puffshroom && plant.ShootOrProductCountdown == 50)
+		plant.FindTargetAndFire(0);
+}
+
 void InitPlantEvents()
 {
 	PlantInitAfterEvent((int)onPlantInitAfter);
@@ -112,4 +120,5 @@ void InitPlantEvents()
 	PlantDieEvent((int)onPlantDie);
 	PVZEvent::PlantUpdateColorEvent((int)onPlantUpdateColor);
 	PVZEvent::StarfruitFindTargetEvent((int)onStarFruitFindTarget);
+	PVZEvent::PlantShootMultipleEvent((int)onPlantShootMultiple);
 }


### PR DESCRIPTION
射手多发里暂时让仙人掌和小喷菇拥有双发，作为测试
射手多发使用的是原版双发的逻辑，无需额外指针
投手多投暂时实装了卷心菜，照搬的CT逻辑，如果重写投手索敌函数，应该也不需要额外的指针+106
PVZ::Plant::Shoot()这个函数感觉有问题？所以我没用