### PR TITLE
八月收尾：磁力菇、三线真正弦轨迹

### DIFF
--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -259,10 +259,9 @@ namespace PVZEvent
 		MagnetShroomMoveItemEvent(int address) : BoolDLLEventTemplate() { Init(address); };
 		MagnetShroomMoveItemEvent() : MagnetShroomMoveItemEvent("onMagnetShroomMoveItem") {};
 	};
-	/// @brief 磁力菇吸引物体时初始化物体的事件，也可以用于吸取时加生命值等
-	/// @note 发生在重置+54和+3C之后，其余事件前
+	/// @brief 磁力菇吸引物体后瞬间的事件，可以修改铁器的属性，也可以用于吸取时加生命值等
 	/// @param 植物，目标僵尸
-	class MagnetShroomAttractItemEvent : public DLLEventTemplate<0x461646, 7, REG_EBX, REG_EBP>
+	class MagnetShroomAttractItemEvent : public DLLEventTemplate<0x4621B3, 5, REG_EBX, REG_EDI>
 	{
 	public:
 		MagnetShroomAttractItemEvent(const char* str) : DLLEventTemplate() { Init(str); };

--- a/pvzdll/MyPlant/MyPlant.hpp
+++ b/pvzdll/MyPlant/MyPlant.hpp
@@ -19,6 +19,10 @@ public:
 	T_PROPERTY(float, MagnetItemXSpeed, __get_MagnetItemXSpeed, __set_MagnetItemXSpeed, 0xE0);
 	/// @brief 磁力菇吸取物品的vy
 	T_PROPERTY(float, MagnetItemYSpeed, __get_MagnetItemYSpeed, __set_MagnetItemYSpeed, 0xE4);
+	/// @brief 磁力菇目标僵尸
+	INT_PROPERTY(MagnetTarget, __get_MagnetTarget, __set_MagnetTarget, 0xE8);
+	/// @brief 磁力菇当前状态，0表示不攻击，1表示攻击
+	T_PROPERTY(byte, MagnetState, __get_MagnetState, __set_MagnetState, 0xEC);
 	/// @brief 狙击豌豆的目标
 	INT_PROPERTY(PeashooterTarget, __get_PeashooterTarget, __set_PeashooterTarget, 0x0E0);
 	/// @brief 路灯花复活植物类型

--- a/pvzdll/MyPlant/implement/MagnetShroom.hpp
+++ b/pvzdll/MyPlant/implement/MagnetShroom.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "../PlantAbility.hpp"
 
 namespace PlantAbility
@@ -23,6 +23,34 @@ namespace PlantAbility
 				plant.Hp += 1000;
 				break;
 			}
+		}
+		bool TickAbility(MyPlant plant)
+		{
+			//索敌X最小的僵尸
+			if (!plant.NotExist && !plant.Squash)
+			{
+				auto item = plant.GetMagnetItem(0);
+				if (item.Type == MagnetItemType::None)
+				{
+					plant.MagnetTarget = 0;
+				}
+				else
+				{
+					float x = 760.0f;
+					auto zombies = plant.GetBoard().GetAllZombies<MyZombie>();
+					int targetid = 0;
+					for (auto& zombie : zombies)
+					{
+						if (!zombie.Hypnotized && !zombie.NotExist && zombie.NotDying && zombie.Row == plant.Row && zombie.X < x)
+						{
+							x = zombie.X;
+							targetid = zombie.GetBaseAddress();
+						}
+					}
+					plant.MagnetTarget = targetid;
+				}
+			}
+			return true;
 		}
 	};
 }

--- a/pvzdll/MyPlant/implement/Threepeater.hpp
+++ b/pvzdll/MyPlant/implement/Threepeater.hpp
@@ -13,6 +13,8 @@ namespace PlantAbility
 		bool onAddProjectile(MyPlant plant, MyProjectile proj, MyZombie zombie)
 		{
 			proj.SpecialFlags = PSF_THREEPEATER_SLIDE_OUT;
+			//新正弦运动的标记
+			proj.OriginalY = proj.Y;
 			return true;
 		}
 	};

--- a/pvzdll/MyPlant/implement/Threepeater.hpp
+++ b/pvzdll/MyPlant/implement/Threepeater.hpp
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include "../PlantAbility.hpp"
 #include "SpecialPlants.hpp"
 
@@ -13,7 +13,7 @@ namespace PlantAbility
 		bool onAddProjectile(MyPlant plant, MyProjectile proj, MyZombie zombie)
 		{
 			proj.SpecialFlags = PSF_THREEPEATER_SLIDE_OUT;
-			//ĞÂÕıÏÒÔË¶¯µÄ±ê¼Ç
+			//æ–°æ­£å¼¦è¿åŠ¨çš„æ ‡è®°
 			proj.OriginalY = proj.Y;
 			return true;
 		}

--- a/pvzdll/MyProjectile/MyProjectile.hpp
+++ b/pvzdll/MyProjectile/MyProjectile.hpp
@@ -19,6 +19,8 @@ public:
 	T_PROPERTY(byte,OriginalRow, __get_OrR, __set_OrR, 0x84);
 	/// @brief 子弹的特殊标记
 	T_PROPERTY(ProjSpecialFlags, SpecialFlags, __get_SpecialFlags, __set_SpecialFlags, 0x84);
+	/// @brief 三线创建子弹时子弹的初始Y坐标，使用了子弹的Z加速度，因此注意其他运动方式对该参数的影响
+	T_PROPERTY(float, OriginalY, __get_OriginalY, __set_OriginalY, 0x48);
 	/// @brief 抛射子弹的弹跳计数器
 	T_PROPERTY(byte, BounceCount, __get_BounceCount, __set_BounceCount, 0x85);
 	/// @brief 子弹的特殊层数，如西瓜大小

--- a/pvzdll/PlantEvents.cpp
+++ b/pvzdll/PlantEvents.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "MyPlant/PlantAbility.hpp"
+#include <cmath>
 
 void onPlantInitAfter(MyPlant plant)
 {
@@ -192,39 +193,72 @@ int onPlantGetDamageRangeFlags(int PlantWeapon,MyPlant plant)
 
 int onMagnetShroomAttractRadius(MyPlant plant,MyZombie zombie)
 {
-	return -1;
+	return 800;
 }
 
 bool onMagnetShroomMoveItem(MyPlant plant)
 {
-	static constexpr float G_constant = -10.0f;
+	//以下内容抄CT
+	if (plant.AnotherCounter > 0)
+	{
+		plant.AnotherCounter -= 1;
+	}
+	else if (plant.MagnetTarget)
+	{
+		plant.MagnetState = 1;
+		//设置初速度
+		//plant.MagnetItemXSpeed
+	}
+	else
+		plant.MagnetState = 0;
+
 	auto item = plant.GetMagnetItem(0);
-	float dx = item.X - plant.ImageX, dy = item.Y - plant.ImageY;
-	float radius_square = dx * dx + dy * dy;
-	float radius = sqrtf(radius_square);
-	//椭圆运动
-	//float ax = dx * G_constant / (radius * radius_square), ay = dy * G_constant / (radius * radius_square);
-	//圆周运动
-	float a = -1.0f;
-	float ax = a * dx / radius, ay = a * dy / radius;
-	plant.MagnetItemXSpeed += ax;
-	plant.MagnetItemYSpeed += ay;
-	item.X += plant.MagnetItemXSpeed;
-	item.Y += plant.MagnetItemYSpeed;
+	if (item.Type != MagnetItemType::None)
+	{
+		int targetid = plant.MagnetTarget;
+		float dx = item.X - plant.ImageX, dy = item.Y - plant.ImageY, vx = plant.MagnetItemXSpeed, vy = plant.MagnetItemYSpeed;
+		if (targetid != 0 && plant.MagnetState != 0)
+		{
+			MyZombie target{ targetid };
+			dx = item.X - target.X; 
+			dy = item.Y - target.Y;
+			if ((dx > 0 && target.X > plant.ImageX) || (dx < 0 && target.X < plant.ImageX))
+			{
+				//音效
+				Creator::CreateLowerSound(LowerSoundType::IronAccessoryHit);
+				Creator::CreateLowerSound(LowerSoundType::HammerHit);
+				//击退
+				if (target.X > plant.ImageX)
+					target.X += 20;
+				else
+					target.X -= 20;
+				plant.MagnetItemXSpeed *= -1;
+				plant.MagnetItemYSpeed *= -1;
+				plant.MagnetState = 0;
+				plant.AnotherCounter = 150;//重置CD
+			}
+		}
+		float ax = -0.004f * dx;
+		float ay = -0.004f * dy;
+		//y坐标阻尼
+		if (dy > 40.0f || dy < -40.0f)
+			ay += -0.05f * vy;
+		//x坐标阻尼
+		if (dx > 50.0f || dx < -50.0f)
+			ax += -0.05f * vx;
+		plant.MagnetItemXSpeed += ax;
+		plant.MagnetItemYSpeed += ay;
+		item.X += plant.MagnetItemXSpeed;
+		item.Y += plant.MagnetItemYSpeed;
+	}
 	return false;
 }
 
 void onMagnetShroomAttractItem(MyPlant plant, MyZombie zombie)
-{
-	auto item = plant.GetMagnetItem(0);
-	float dx = item.X - plant.ImageX, dy = item.Y - plant.ImageY;
-	float radius_square = dx * dx + dy * dy;
-	float radius = sqrtf(radius_square);
-	float a = 1.0f;
-	float v = sqrtf(a * radius);
-	plant.MagnetItemXSpeed = v * dy / radius;
-	plant.MagnetItemYSpeed = v * dx * -1.0f / radius;
+{	
 	plant.AttributeCountdown = 10000;
+	plant.MagnetState = 0;
+	plant.AnotherCounter = 100;//重置CD
 	return;
 }
 void onMagnetShroomClearItem(MyPlant plant)

--- a/pvzdll/ProjectileEvents.cpp
+++ b/pvzdll/ProjectileEvents.cpp
@@ -73,11 +73,14 @@ bool onProjectileRemove(MyProjectile proj)
 
 bool onProjectileSlideMotion(MyProjectile proj)
 {
-	static constexpr int CYCLE_TIME = 50;
+	//static constexpr int CYCLE_TIME = 50;
 	if (proj.SpecialFlags)
 	{
+		proj.YSpeed -= 0.001f * (proj.Y - proj.OriginalY);//简谐运动，对于a = kx,周期T= 2*pi/sqrt(k)
 		proj.Y += proj.YSpeed;
 		proj.AdjustRow();
+		//之前的伪正弦运动，本质上是两段指数运动
+		/*
 		if (proj.SpecialFlags == PSF_THREEPEATER_SLIDE_OUT)
 		{
 			proj.YSpeed *= 0.97f;
@@ -96,6 +99,7 @@ bool onProjectileSlideMotion(MyProjectile proj)
 				proj.SpecialFlags = PSF_THREEPEATER_SLIDE_OUT;
 			}
 		}
+		*/
 		proj.ShadowY += proj.YSpeed;
 		return false;
 	}


### PR DESCRIPTION
磁力菇目前使用和原CT相同的简谐运动，但部分细节可以优化的更好
例如目标位置目前设置在头上，可根据铁器类型和僵尸类型修改目标位置

目前没有增加铁器消耗与造成伤害的代码

直到寒假之前我的时间都不多了，求有人帮忙把剩下的代码写完