### PR TITLE
指针调整与错误修复

### DIFF
--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -921,7 +921,7 @@ namespace PVZEvent
 
 				PUSHDWORD(0x52B17A),
 				RET,
-				PUSHDWORD(0x52B279),
+				PUSHDWORD(0x52B278),
 				RET,
 			};
 			builder.add_bytes(STRING(after));

--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -921,7 +921,7 @@ namespace PVZEvent
 
 				PUSHDWORD(0x52B17A),
 				RET,
-				PUSHDWORD(0x52B278),
+				PUSHDWORD(0x52B180),
 				RET,
 			};
 			builder.add_bytes(STRING(after));

--- a/pvzdll/MyEvents.hpp
+++ b/pvzdll/MyEvents.hpp
@@ -1057,7 +1057,7 @@ namespace PVZEvent
 	/// @brief 车类僵尸碾压结算事件。
 	/// @param 触发事件的僵尸
 	/// @return 是否结算原版碾压过程。
-	class ZombieCheckSquishEvent : public BoolDLLEventTemplate<0x52EDB0, 6, 0x52EEEC, MEM_ESP_ADD(0x20)>
+	class ZombieCheckSquishEvent : public BoolDLLEventTemplate<0x52EDB0, 6, 0x52EEEC, MEM_ESP_ADD(0x24)>
 	{
 	public:
 		ZombieCheckSquishEvent(const char* str) : BoolDLLEventTemplate() { Init(str); };

--- a/pvzdll/MyZombie/MyZombie.cpp
+++ b/pvzdll/MyZombie/MyZombie.cpp
@@ -23,7 +23,7 @@ ZombieAbility::ZombiePTR ZombieAbility::GetAbility(ZombieType::ZombieType type)
 
 int MyZombie::GetBountyXP()
 {
-	if (this->Hypnotized || this->Unknown == 9 || this->Type == ZombieType::ConeheadZombie)
+	if (this->Hypnotized || this->Type == ZombieType::ConeheadZombie)
 		return 0;
 	else
 		return this->BodyMaxHealth + this->HelmMaxHealth + this->ShieldMaxHealth;

--- a/pvzdll/MyZombie/MyZombie.hpp
+++ b/pvzdll/MyZombie/MyZombie.hpp
@@ -13,13 +13,11 @@ public:
 	INT_PROPERTY(FromWave, __get_FrW, __set_FrW, 0x6C);
 	/// @brief 是否掉落过掉落物
 	T_PROPERTY(byte, DroppedLoot, __get_DrL, __set_DrL, 0x70);
-	T_PROPERTY(byte, Unknown, __get_Un, __set_Un, 0x71);
 	/// @brief 精英类别
 	/// @deprecated 请使用 WAVE_ELITE 系列常量和 FromWave 替代之。
 	T_PROPERTY(byte, EliteType, __get_ElT, __set_ElT, 0x72);
 	/// @brief 是否受钢地刺影响，啃食伤害减半
 	T_PROPERTY(BOOLEAN, IsWeak, __get_IsW, __set_IsW, 0x73);
-	INT_PROPERTY(Unknown2, __get_Un2, __set_Un2, 0x80);
 	/// @brief 召唤该僵尸的植物的 ID
 	/// @note 由于适配问题，这里暂时直接存基址
 	INT_PROPERTY(SourceID, __get_SoID, __set_SoID, 0x0E8);

--- a/pvzdll/MyZombie/MyZombie.hpp
+++ b/pvzdll/MyZombie/MyZombie.hpp
@@ -13,11 +13,17 @@ public:
 	INT_PROPERTY(FromWave, __get_FrW, __set_FrW, 0x6C);
 	/// @brief 是否掉落过掉落物
 	T_PROPERTY(byte, DroppedLoot, __get_DrL, __set_DrL, 0x70);
+	/// @brief 僵尸的特殊标记，=1表示被精英小丑标记爆炸，=9表示虚影
+	/// @deprecated 精英小丑与虚影拟定废除或者重做，不再使用该指针，该属性仅用于协助阅读CT！
+	T_PROPERTY(byte, SpecialFlag, __get_SpecialFlag, __set_SpecialFlag, 0x71);
 	/// @brief 精英类别
 	/// @deprecated 请使用 WAVE_ELITE 系列常量和 FromWave 替代之。
 	T_PROPERTY(byte, EliteType, __get_ElT, __set_ElT, 0x72);
 	/// @brief 是否受钢地刺影响，啃食伤害减半
 	T_PROPERTY(BOOLEAN, IsWeak, __get_IsW, __set_IsW, 0x73);
+	/// @brief 燃烬层数过去使用的地址
+	/// @deprecated 已转移至FlameStack属性，不再使用该指针，该属性仅用于协助阅读CT！
+	INT_PROPERTY(DeprecatedFlameStack, __get_DeprecatedFlameStack, __set_DeprecatedFlameStack, 0x80);
 	/// @brief 召唤该僵尸的植物的 ID
 	/// @note 由于适配问题，这里暂时直接存基址
 	INT_PROPERTY(SourceID, __get_SoID, __set_SoID, 0x0E8);
@@ -32,21 +38,22 @@ public:
 	/// @brief 僵尸的掉落速度，原版中只有小鬼和水族馆僵尸使用该指针；负数表示下落，正数表示上升
 	T_PROPERTY(float, FallSpeed, __get_FallSpeed, __set_FallSpeed, 0x120);
 	/// @brief 巨人变种类型
-	INT_PROPERTY(GargantaurType, __get_GaT, __set_GaT, 0x128);
+	/// @deprecated 已转移至VariantType属性，不再使用该指针，该属性仅用于协助阅读CT！
+	INT_PROPERTY(DeprecatedGargantaurType, __get_GaT, __set_GaT, 0x128);
 	/// @brief 金色标记
 	INT_PROPERTY(GoldMark, __get_GoM, __set_GoM, 0x12C);
 	/// @brief 伤害免疫持续时间
 	INT_PROPERTY(InvulnerableDuration, __get_InD, __set_InD, 0x12C);
-	/// @brief 豌豆僵尸变种类型
-	INT_PROPERTY(PeaHeadType, __get_PeHT, __set_PeHT, 0x138);
+	/// @brief 僵尸血量点数标记，非盲盒开出的僵尸该值为0
+	T_PROPERTY(byte, HpPoint, __get_HpPoint, __set_HpPoint, 0x138);
 	/// @brief 僵尸反向标记，1=反向回头，2=反向出屏幕
 	T_PROPERTY(byte, IsWalkingBackwards, __get_IsWalkingBackwards, __set_IsWalkingBackwards, 0x13C);
 	/// @brief 僵尸寒意层数，上限30层，每层减速2%
 	T_PROPERTY(byte, FrostStack, __get_FrostStack, __set_FrostStack, 0x13D);
 	/// @brief 僵尸显示颜色标记，0为不显示，1为毒，2为冰，3为火
 	T_PROPERTY(byte, ColorFlag, __get_ColorFlag, __set_ColorFlag, 0x13E);
-	/// @brief 僵尸血量点数标记，非盲盒开出的僵尸该值为0
-	T_PROPERTY(byte, HpPoint, __get_HpPoint, __set_HpPoint, 0x13F);
+	/// @brief 非精英僵尸变种类型
+	T_PROPERTY(ZombieVariantType::ZombieVariantType, VariantType, __get_VariantType, __set_VariantType, 0x13F);
 	/// @brief 毒的层数
 	INT_PROPERTY(PoisonStack, __get_PoS, __set_PoS, 0x140);
 	/// @brief 燃烬层数

--- a/pvzdll/PlantEvents.cpp
+++ b/pvzdll/PlantEvents.cpp
@@ -403,41 +403,50 @@ bool onPlantDying(MyPlant plant, PlantDyingType dyingtype)
 
 void InitPlantEvents()
 {
+	// 植物初始化与销毁相关
 	PlantInitAfterEvent((int)onPlantInitAfter);
-	PlantUpdateAbilityEvent((int)onPlantUpdateAbility);
-	GetPlantAttackRectEvent((int)OverwritePlantAttackRect);
-	PVZEvent::PlantSpecialAnimateEvent((int)onPlantSpecialAnimate);
-	PVZEvent::PlantDamageZombieEvent((int)onPlantDamageZombie);
 	PlantDieEvent((int)onPlantDie);
+
+	// 植物绘制与动画相关
+	PVZEvent::PlantSpecialAnimateEvent((int)onPlantSpecialAnimate);
 	PVZEvent::PlantUpdateColorEvent((int)onPlantUpdateColor);
-	PVZEvent::StarfruitFindTargetEvent((int)onStarFruitFindTarget);
+
+	// 植物攻击相关
+	GetPlantAttackRectEvent((int)OverwritePlantAttackRect);
+	PVZEvent::PlantGetDamageRangeFlagsEvent((int)GetPlantDamageRangeFlags);
 	PVZEvent::PlantUpdateShooterEvent((int)onPlantUpdateShooter);
-	PVZEvent::PlantPultSkipEvent((int)onPlantPultSkip);
-	PVZEvent::PlantPultMultipleEvent((int)onPlantPultMultiple);
+	PVZEvent::PlantFindTargetRTEvent((int)onPlantFindTargetRT);
+	PVZEvent::StarfruitFindTargetEvent((int)onStarFruitFindTarget);
 	PVZEvent::PlantUpdateShootingEvent((int)onPlantUpdateShooting);
 	PVZEvent::PlantFireEvent((int)onPlantFire);
-	PVZEvent::PlantFindTargetRTEvent((int)onPlantFindTargetRT);
-	PVZEvent::PlantGetDamageRangeFlagsEvent((int)GetPlantDamageRangeFlags);
-	PVZEvent::SingleUsePlantUpdateEvent((int)onSingleUsePlantUpdate);
+	PVZEvent::PlantPultSkipEvent((int)onPlantPultSkip);
+	PVZEvent::PlantPultMultipleEvent((int)onPlantPultMultiple);
+	PVZEvent::PlantDamageZombieEvent((int)onPlantDamageZombie);
+
+	// 植物受击死亡相关
 	PVZEvent::PlantDyingEvent((int)onPlantDying);
 
-	//磁力菇
+	// 植物特性相关
+	PlantUpdateAbilityEvent((int)onPlantUpdateAbility);
+	PVZEvent::SingleUsePlantUpdateEvent((int)onSingleUsePlantUpdate);
+	// 磁力菇
 	PVZEvent::MagnetShroomAttractRadiusEvent((int)onMagnetShroomAttractRadius);
 	PVZEvent::MagnetShroomMoveItemEvent((int)onMagnetShroomMoveItem);
 	PVZEvent::MagnetShroomAttractItemEvent((int)onMagnetShroomAttractItem);
 	PVZEvent::MagnetShroomClearItemEvent((int)onMagnetShroomClearItem);
-	//三线射手
+	// 三线射手
 	PVZEvent::ThreepeaterLaunchEvent((int)onThreepeaterLaunch);
-	//魅惑菇
+	// 魅惑菇
 	PVZEvent::HypnoShroomEatenEvent((int)onHypnoShroomEaten);
-	//缠绕海草
+	// 缠绕海草
 	PVZEvent::TangleKelpKillZombieEvent((int)onTangleKelpKillZombie);
 	PVZEvent::TangleKelpUpdateGrabbingEvent((int)onTangleKelpUpdateGrabbing);
 	PVZEvent::TangleKelpTargetAfterEvent((int)onTangleKelpTargetAfter);
+	// 玉米投手
+	PVZEvent::KernelPult::JudgeButterEvent((int)IsKernelPultCastButter);
+
 	//目前不会崩溃了，但植物不索敌，暂时先去掉了
 	//PVZEvent::PlantFindTargetZombiePriorityEvent((int)GetPlantFindTargetZombiePriority);
-
-	PVZEvent::KernelPult::JudgeButterEvent((int)IsKernelPultCastButter);
 
 	//磁力菇只访问+C8 ~ +D8
 	PVZ::Memory::WriteMemory<int>(0x461DA6, 1);

--- a/pvzdll/ProjectileEvents.cpp
+++ b/pvzdll/ProjectileEvents.cpp
@@ -271,23 +271,32 @@ bool onProjectileDivert(MyProjectile proj)
 
 void InitProjectileEvents()
 {
+	// 子弹初始化与销毁相关
+	PVZEvent::ProjectileInitAfterEvent((int)onProjectileInitAfter);
 	ProjectileRemoveEvent((int)onProjectileRemove);
-	PlantAddProjectileEvent((int)onPlantAddProjectile);
-	PVZEvent::ProjectileDamageZombieEvent((int)onProjDamageZombie);
+
+	// 子弹总更新与绘制相关
+	PVZEvent::ProjectileSkipUpdateAndDrawEvent((int)onProjectileSkipUpdateAndDraw);
+	PVZEvent::ProjectileUpdateEvent((int)onProjectileUpdate);
 	PVZEvent::ProjectileImageEvent((int)GetProjectileImage);
 	PVZEvent::ProjectileImageSizeEvent((int)GetProjectileImageSize);
-	PVZEvent::ProjectileUpdateEvent((int)onProjectileUpdate);
-	PVZEvent::ProjectileSlideMotionEvent((int)onProjectileSlideMotion);
-	PVZEvent::ProjectileInitAfterEvent((int)onProjectileInitAfter);
 	PVZEvent::FireballInitColorEvent((int)onFireballInitColor);
-	PVZEvent::ProjectileCheckExpireEvent((int)IsProjExpire);
+
+	PlantAddProjectileEvent((int)onPlantAddProjectile);
 	PVZEvent::PlantAddProjDamageRangeFlagsEvent((int)onPlantAddProjDamageRangeFlags);
-	PVZEvent::ProjectileImpactEvent((int)onProjectileImpact);
+
+	// 子弹碰撞相关
+	PVZEvent::ProjectileCheckExpireEvent((int)IsProjExpire);
 	PVZEvent::ProjectileHitDiversionEvent((int)onProjectileDivert);
-	PVZEvent::ProjectileSkipUpdateAndDrawEvent((int)onProjectileSkipUpdateAndDraw);
 	PVZEvent::ProjectileFindZombieTargetSkipEvent((int)onProjectileFindZombieTargetSkip);
 
+	// 子弹碰撞效果相关
+	PVZEvent::ProjectileImpactEvent((int)onProjectileImpact);
+	PVZEvent::ProjectileDamageZombieEvent((int)onProjDamageZombie);
+
+	// 子弹运动相关
 	PVZEvent::ProjectileUpdatePiercingMotionEvent((int)onProjectileUpdatePiercingMotion);
+	PVZEvent::ProjectileSlideMotionEvent((int)onProjectileSlideMotion);
 
 	//冰豌豆和冰瓜不附加原版减速
 	PVZ::Memory::WriteMemory<byte>(0x46D2A1, 0);

--- a/pvzdll/ProjectileEvents.cpp
+++ b/pvzdll/ProjectileEvents.cpp
@@ -282,6 +282,7 @@ void InitProjectileEvents()
 	PVZEvent::ProjectileImageSizeEvent((int)GetProjectileImageSize);
 	PVZEvent::FireballInitColorEvent((int)onFireballInitColor);
 
+	// 子弹创建相关
 	PlantAddProjectileEvent((int)onPlantAddProjectile);
 	PVZEvent::PlantAddProjDamageRangeFlagsEvent((int)onPlantAddProjDamageRangeFlags);
 

--- a/pvzdll/RandPool.cpp
+++ b/pvzdll/RandPool.cpp
@@ -85,10 +85,8 @@ void onRandomZombieDropHelm(MyZombie zombie)
 		///651185跳到了651373和6512d5,不知道是干啥的一段代码，没搬
 	}
 
-	child_zombie.Unknown2 = zombie.Unknown2;
-	if (zombie.Unknown == 1)
-		child_zombie.Unknown = 1;
-	return;
+	//僵尸的各种属性继承
+	child_zombie.FlameStack = zombie.FlameStack;
 }
 
 void InitRandomZombieEvents()

--- a/pvzdll/RandPool.cpp
+++ b/pvzdll/RandPool.cpp
@@ -20,15 +20,16 @@ void onRandomZombieDropHelm(MyZombie zombie)
 
 	zombie.Remove();
 
-	int type = 0, elite_type = -1;
+	ZombieType::ZombieType type = ZombieType::None;
+	int elite_type = -1;
 	if (zombie.Hypnotized)
 		type = ::hypno_pool[Creator::Rand(sizeof(hypno_pool) / sizeof(ZombieType::ZombieType))];
 	else
 	{
 		elite_type = Creator::Rand(2);
-		type = Creator::Rand(33);
-		if (type == 25)type = 26;//僵王换豌豆
-		if (type == 20)type = 27;//蹦极换坚果
+		type = static_cast<ZombieType::ZombieType>(Creator::Rand(33));
+		if (type == ZombieType::DrZomboss)type = ZombieType::PeashooterZombie;//僵王换豌豆
+		if (type == ZombieType::BungeeZombie)type = ZombieType::WallnutZombie;//蹦极换坚果
 
 		switch (type)
 		{
@@ -58,7 +59,7 @@ void onRandomZombieDropHelm(MyZombie zombie)
 	}
 
 	MyBoard board = zombie.GetBoard();
-	MyZombie child_zombie{ board.AddZombieInRow(static_cast<ZombieType::ZombieType>(type), zombie.Row, elite_type) };
+	MyZombie child_zombie{ board.AddZombieInRow(type, zombie.Row, elite_type) };
 	if (zombie.Hypnotized)
 		child_zombie.Hypnotized = true;
 	PVZ::CreateParticleSystem(zombie.X + 40.0f, zombie.Y + 65.0f, zombie.Layer + 100, EffectType::IMITATER_TRANSFORMING);

--- a/pvzdll/ZombieEvents.cpp
+++ b/pvzdll/ZombieEvents.cpp
@@ -637,47 +637,60 @@ bool onPogoUpdateActions(MyZombie zombie)
 
 void InitZombieEvents()
 {
-	PlantTakeDamageEvent((int)onPlantTakeDamage);
-	ZombieDropLootEvent((int)onZombieDropLoot);
+	// 僵尸初始化相关
 	ZombieInitAfterEvent((int)onZombieInitAfter);
-	PVZEvent::ZombieSquishPlantEvent((int)onZombieSquishPlant);
 	PVZEvent::LoadPlainZombieReanimBeforeEvent((int)onLoadPlainZombieReanimBefore);
+
+	// 僵尸绘制相关
+	PVZEvent::ZombieUpdateColorEvent((int)onZombieUpdateColor);
+	PVZEvent::ZombieOverrideDrawPosEvent((int)OverrideZombieDrawPos);
+
+	// 僵尸攻击相关
+	PVZEvent::ZombieFindTargetIntervalEvent((int)onZombieFindTargetInterval);
+	ZombieTargetPlantEvent((int)onZombieCanTargetPlant);
+	PVZEvent::ZombieSquishPlantEvent((int)onZombieSquishPlant);
+	PVZEvent::ZombieCheckSquishEvent((int)onZombieCheckSquish);
+	PVZEvent::ZombieAddProjectileEvent((int)onZombieAddProj);
+	ZombieEatSoundEvent((int)onZombieEatSound);
+	PlantTakeDamageEvent((int)onPlantTakeDamage);
+
+	// 僵尸受击相关
+	PVZEvent::ZombieEffectedByDamageRangeEvent((int)onZombieEffectedByDamageRange);
+	ZombieTakeDmgEvent((int)onZombieTakeDmg);
+	ZombieDropLootEvent((int)onZombieDropLoot);
+
+	// 僵尸移动相关
 	PVZEvent::ZombieUpdateWalkingSpeedEvent((int)onZombieUpdateWalkingSpeed);
 	PVZEvent::ZombieIsWalkingBackwardsEvent((int)onZombieIsWalkingBackwards);
+	PVZEvent::ZombiePickRandomSpeedEvent((int)onZombiePickRandomSpeed);
 	PVZEvent::ZombieApplyAnimSpeedEvent((int)onZombieApplyAnimSpeed);
-	ZombieUpdatePlayingEvent((int)onZombieUpdatePlaying);
-	PVZEvent::ZombieUpdateColorEvent((int)onZombieUpdateColor);
-	PVZEvent::ZombieUpdateAbilityEvent((int)onZombieUpdateAbility);
-	PVZEvent::ClownZombiePopEvent((int)onClownZombiePop);
-	PVZEvent::HypnotizedClownZombiePopEvent((int)onHypnotizedClownZombiePop);
-	ZombieEatSoundEvent((int)onZombieEatSound);
 	PVZEvent::ZombieWalkIntoWaterEvent((int)onZombieWalkIntoWater);
 	PVZEvent::ZombieWalkOutOfWaterEvent((int)onZombieWalkOutOfWater);
 	PVZEvent::ZombieUpdateFallingEvent((int)onZombieUpdateFalling);
 	PVZEvent::ZombieFallOnGroundEvent((int)onZombieFallOnGround);
-	ZombieTargetPlantEvent((int)onZombieCanTargetPlant);
-	ZombieTakeDmgEvent((int)onZombieTakeDmg);
-	PVZEvent::ZombiePickRandomSpeedEvent((int)onZombiePickRandomSpeed);
 
-	PVZEvent::ZombieFindTargetIntervalEvent((int)onZombieFindTargetInterval);
-	PVZEvent::ZombieEffectedByDamageRangeEvent((int)onZombieEffectedByDamageRange);
-
+	// 僵尸特性相关
+	ZombieUpdatePlayingEvent((int)onZombieUpdatePlaying);
+	PVZEvent::ZombieUpdateAbilityEvent((int)onZombieUpdateAbility);
+	// 撑杆僵尸
 	PVZEvent::PoleVaulter::HalfJumpEvent((int)onPoleVaulterHalfJump);
-	PVZEvent::ZombieOverrideDrawPosEvent((int)OverrideZombieDrawPos);
-
+	// 小丑僵尸
+	PVZEvent::ClownZombiePopEvent((int)onClownZombiePop);
+	PVZEvent::HypnotizedClownZombiePopEvent((int)onHypnotizedClownZombiePop);
+	// 投篮车僵尸
 	PVZEvent::CatapultTargetSkipEvent((int)onCatapultTargetSkip);
 	PVZEvent::CatapultZombieFireEvent((int)onCatapultZombieFire);
-	PVZEvent::ZombieCheckSquishEvent((int)onZombieCheckSquish);
-	PVZEvent::ZombieAddProjectileEvent((int)onZombieAddProj);
+	// 机枪头僵尸
 	PVZEvent::GatlingZombieJudgeShootEvent((int)IsGatlingZombieShoot);
+	// 巨人僵尸
 	PVZEvent::GargantaurThrowAfterEvent((int)onGargantaurThrowAfter);
 	PVZEvent::GargantaurJudgeXFixEvent();
 	PVZEvent::GargantaurJudgeSquishEvent((int)onGargantaurJudgeSquish);
 	PVZEvent::GargantaurSquishPlantEvent((int)onGargantaurSquishPlant);
-
+	// 跳跳僵尸
 	PVZEvent::PogoUpdateHeightEvent((int)onPogoUpdateHeight);
 	PVZEvent::PogoUpdateActionsEvent((int)onPogoUpdateActions);
-
+	// 辣椒头僵尸
 	PVZEvent::JalapenoHeadBurnBeforeEvent((int)onJalapenoHeadBurnBefore);
 
 	//修改冰道持续时间

--- a/pvzdll/ZombieEvents.cpp
+++ b/pvzdll/ZombieEvents.cpp
@@ -643,7 +643,8 @@ void InitZombieEvents()
 
 	// 僵尸绘制相关
 	PVZEvent::ZombieUpdateColorEvent((int)onZombieUpdateColor);
-	PVZEvent::ZombieOverrideDrawPosEvent((int)OverrideZombieDrawPos);
+	//这个事件会使僵尸无法绘制，暂时禁用
+	//PVZEvent::ZombieOverrideDrawPosEvent((int)OverrideZombieDrawPos);
 
 	// 僵尸攻击相关
 	PVZEvent::ZombieFindTargetIntervalEvent((int)onZombieFindTargetInterval);

--- a/pvzdll/ZombieEvents.cpp
+++ b/pvzdll/ZombieEvents.cpp
@@ -50,7 +50,6 @@ void onZombieDropLoot(MyZombie zombie)
 void onZombieInitAfter(MyZombie zombie)
 {
 	zombie.IsWalkingBackwards = 0;
-	zombie.Unknown = 0;
 	zombie.IsWeak = false;
 	
 	zombie.ColorFlag = 0;
@@ -60,8 +59,7 @@ void onZombieInitAfter(MyZombie zombie)
 	zombie.SourceLevel = 0;
 	zombie.GhostFlameMark = 0;
 
-	zombie.GargantaurType = 0;
-	zombie.PeaHeadType = 0;
+	zombie.VariantType = 0;
 	zombie.InvulnerableDuration = 0;
 
 	zombie.FrostStack = 0;
@@ -367,11 +365,11 @@ bool onZombiePickRandomSpeed(MyZombie zombie)
 	case ZombieType::Gigagargantuar:
 		if (PVZ::Memory::ReadMemory<int>(0x701190))
 		{
-			zombie.GargantaurType = 1;
+			zombie.VariantType = 1;
 			zombie.Speed = Creator::RandFloat(0.14f) + 0.23f + 0.66f;
 		}
 		if (PVZ::Memory::ReadMemory<int>(0x701200))
-			zombie.GargantaurType = 2;
+			zombie.VariantType = 2;
 		return false;
 	default:
 		break;
@@ -493,7 +491,7 @@ void onZombieAddProj(MyZombie zombie, MyProjectile proj)
 		if (zombie.Hypnotized)
 		{
 			proj.Type = ProjectileType::Pea;
-			if (zombie.PeaHeadType == 1)
+			if (zombie.VariantType == ZombieVariantType::SnowPeaHead)
 				proj.Type = ProjectileType::SnowPea;
 			proj.X += 100;
 			proj.DamageAbility = PVZ::DRF_GROUND;

--- a/pvzdll/ZombieEvents.cpp
+++ b/pvzdll/ZombieEvents.cpp
@@ -244,6 +244,7 @@ bool onZombieUpdateAbility(MyZombie zombie)
 			}
 		}
 	}
+	// 空投的车类不更新
 	return zombie.ZombieHeight != 9 || (zombie.Type != ZombieType::CatapultZombie && zombie.Type != ZombieType::Zomboin);
 }
 
@@ -354,7 +355,7 @@ bool onZombiePickRandomSpeed(MyZombie zombie)
 	default:
 		break;
 	}
-
+	/*
 	switch (zombie.Type)
 	{
 	case ZombieType::Gargantuar:
@@ -370,7 +371,7 @@ bool onZombiePickRandomSpeed(MyZombie zombie)
 	default:
 		break;
 	}
-
+	*/
 	return true;
 }
 

--- a/pvzdll/ZombieEvents.cpp
+++ b/pvzdll/ZombieEvents.cpp
@@ -319,10 +319,6 @@ void onZombieFallOnGround(MyZombie zombie)
 
 int onZombieCanTargetPlant(MyZombie zombie, MyPlant plant, int AttackType)
 {
-	if (zombie.IsTangleKelpTarget())
-	{
-		return 0;
-	}
 	if (zombie.IsLaunched)
 		return 0;
 	if (zombie.State == ZombieState::DIGGER_WALK_RIGHT && zombie.X < 130)

--- a/pvzdll/dllmain.cpp
+++ b/pvzdll/dllmain.cpp
@@ -16,6 +16,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 		InitProjectileEvents();
 		InitZombieEvents();
 		InitCoinEvents();
+		InitRandomZombieEvents();
 		break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:

--- a/pvzdll/framework.h
+++ b/pvzdll/framework.h
@@ -64,3 +64,14 @@ enum PlantDyingType
 	DYING_HYPNOSHROOM_EATEN,
 	DYING_BUNGEE_STOLEN
 };
+
+/// @brief 非精英僵尸的变种类型
+namespace ZombieVariantType
+{
+	typedef unsigned char ZombieVariantType;
+
+	constexpr ZombieVariantType None = 0;
+
+	constexpr ZombieVariantType SnowPeaHead = 1;
+
+}


### PR DESCRIPTION
1. 已标注+71 Unknown和+80 Unknown2指针。
2. 将巨人变种指针与豌豆头变种指针 统一为byte +13F VariantType。其余僵尸的非精英变种此后请使用该指针。
3. 在初始化中排序分类了事件，使其更方便阅读。
4. 修复部分事件的错误。
5. 补充RandPool的事件初始化。
6. 删除了不必要的僵尸啃咬判断。原版在CheckIfPreyCaught中已经判断过僵尸是否为水草目标。